### PR TITLE
Add Convergence option when tolerance is of interest

### DIFF
--- a/examples/Test1FDE.jl
+++ b/examples/Test1FDE.jl
@@ -12,7 +12,7 @@ function F(t, n, β, y)
 
 end
 
-t, Yapp = FDEsolver(F, tSpan, y0, β)
+t, Yapp = FDEsolver(F, tSpan, y0, β, StopIt = "Convergence")
 
 plot(t, Yapp, linewidth = 5, title = "Solution of a system of 2 FDEs", xaxis = "Time (t)", yaxis = "y(t)", label = "Approximation 1")
 plot!(t, t -> (t.^8 - 3 * t .^ (4 + β / 2) + 9/4 * t.^β), lw = 3, ls = :dash, label = "Exact solution 1")

--- a/examples/TestLVSystem.jl
+++ b/examples/TestLVSystem.jl
@@ -1,5 +1,3 @@
-using Revise
-push!(LOAD_PATH, "./FdeSolver.jl/src/")
 using FdeSolver
 using Plots
 

--- a/examples/TestLVSystem.jl
+++ b/examples/TestLVSystem.jl
@@ -24,7 +24,7 @@ function F(t, n, β, y)
 
 end
 
-t, Yapp = FDEsolver(F, tSpan, y0, β)
+t, Yapp = FDEsolver(F, tSpan, y0, β, nc = "Convergence")
 
 plot(t, Yapp, linewidth = 5, title = "Solution to LV model with 2 FDEs",
      xaxis = "Time (t)", yaxis = "y(t)", label = "Approximation")

--- a/examples/TestLVSystem.jl
+++ b/examples/TestLVSystem.jl
@@ -1,3 +1,5 @@
+using Revise
+push!(LOAD_PATH, "./FdeSolver.jl/src/")
 using FdeSolver
 using Plots
 
@@ -24,7 +26,7 @@ function F(t, n, β, y)
 
 end
 
-t, Yapp = FDEsolver(F, tSpan, y0, β, nc = "Convergence")
+t, Yapp = FDEsolver(F, tSpan, y0, β, StopIt = "Convergence")
 
 plot(t, Yapp, linewidth = 5, title = "Solution to LV model with 2 FDEs",
      xaxis = "Time (t)", yaxis = "y(t)", label = "Approximation")

--- a/examples/TestSIRm.jl
+++ b/examples/TestSIRm.jl
@@ -22,7 +22,7 @@ function F(t, n, α, y)
 
 end
 
-t, Yapp = FDEsolver(F, tSpan, y0, α, h = h)
+t, Yapp = FDEsolver(F, tSpan, y0, α, h = h, StopIt = "Convergence")
 
 plot(t, Yapp, linewidth = 5, title = "Numerical solution of SIR model",
      xaxis = "Time (t)", yaxis = "y(t)")

--- a/src/FdeSolver.jl
+++ b/src/FdeSolver.jl
@@ -1,7 +1,3 @@
-# """
-# $(DocStringExtensions.README)
-# """
-
 module FdeSolver
 
 using SpecialFunctions

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,8 +1,4 @@
-"""
-    FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc = 2, tol = 10^(-6), itmax = 30)
-Solves fractional differential equations with a predictor-corrector approach.
-"""
-function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc = 2, tol = 10^(-6), itmax = 30)
+function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc::Any = 3, tol = 10e-10, itmax = 10)
 
     # Time discretization
     N::Int64 = cld(tSpan[2] - tSpan[1], h)
@@ -23,15 +19,32 @@ function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc = 2, tol = 10^(-6), it
             # Y1
             Y[2, :] .= T0 .+ h .^ β .* F(t, n, β, Y, par...) ./ Γ(β .+ 1)
 
-            for j in 1:nc
+            if nc == "Convergence"
 
-                # Y11
-                Y11 = T0 .+ h .^ β .* β .* F(t, n, β, Y, par...) ./ Γ(β .+ 2) .+ h .^ β .* F(t, n + 1, β, Y, par...) ./ Γ(β .+ 2)
-                σ = sqrt(sum((Y11 .- Y[2, :]) .^ 2))
-                Y[2, :] .= Y11
+                σ = 1.1 * tol
 
-                if (σ < tol || j >= itmax)
-                    break
+                while (σ > tol || j < itmax)
+
+                    # Y11
+                    Y11 = T0 .+ h .^ β .* β .* F(t, n, β, Y, par...) ./ Γ(β .+ 2) .+ h .^ β .* F(t, n + 1, β, Y, par...) ./ Γ(β .+ 2)
+                    σ = sqrt(sum((Y11 .- Y[2, :]) .^ 2))
+                    Y[2, :] .= Y11
+
+                end
+
+            else
+
+                for j in 1:nc
+
+                    # Y11
+                    Y11 = T0 .+ h .^ β .* β .* F(t, n, β, Y, par...) ./ Γ(β .+ 2) .+ h .^ β .* F(t, n + 1, β, Y, par...) ./ Γ(β .+ 2)
+                    σ = sqrt(sum((Y11 .- Y[2, :]) .^ 2))
+                    Y[2, :] .= Y11
+
+                    if σ < tol
+                        warn('Correction below tolerance!')
+                    end
+
                 end
 
             end
@@ -43,15 +56,32 @@ function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc = 2, tol = 10^(-6), it
             # Yp
             Y[n + 1, :] .= T0 .+ h .^ β .* (ϕ .- α(0, β) .* F(t, n - 1, β, Y, par...) .+ 2 .* α(0, β) .* F(t, n, β, Y, par...))
 
-            for j in 1:nc
+            if nc == "Convergence"
 
-                # Y2
-                Y2 = T0 .+ h .^ β .* (ϕ .+ α(0, β) .* F(t, n + 1, β, Y, par...))
-                σ = sqrt(sum((Y2 .- Y[2, :]) .^ 2))
-                Y[n + 1, :] .= Y2
+                σ = 1.1 * tol
 
-                if (σ < tol || j >= itmax)
-                    break
+                while (σ > tol || j < itmax)
+
+                    # Y2
+                    Y2 = T0 .+ h .^ β .* (ϕ .+ α(0, β) .* F(t, n + 1, β, Y, par...))
+                    σ = sqrt(sum((Y2 .- Y[2, :]) .^ 2))
+                    Y[n + 1, :] .= Y2
+
+                end
+
+            else
+
+                for j in 1:nc
+
+                    # Y2
+                    Y2 = T0 .+ h .^ β .* (ϕ .+ α(0, β) .* F(t, n + 1, β, Y, par...))
+                    σ = sqrt(sum((Y2 .- Y[2, :]) .^ 2))
+                    Y[n + 1, :] .= Y2
+
+                    if σ < tol
+                        warn('Correction below tolerance!')
+                    end
+
                 end
 
             end

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,4 +1,4 @@
-function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc::Any = 3, tol = 10e-10, itmax = 10)
+function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc = 3, StopIt = "Standard", tol = 10e-10, itmax = 10)
 
     # Time discretization
     N::Int64 = cld(tSpan[2] - tSpan[1], h)
@@ -19,20 +19,7 @@ function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc::Any = 3, tol = 10e-10
             # Y1
             Y[2, :] .= T0 .+ h .^ β .* F(t, n, β, Y, par...) ./ Γ(β .+ 1)
 
-            if nc == "Convergence"
-
-                σ = 1.1 * tol
-
-                while (σ > tol || j < itmax)
-
-                    # Y11
-                    Y11 = T0 .+ h .^ β .* β .* F(t, n, β, Y, par...) ./ Γ(β .+ 2) .+ h .^ β .* F(t, n + 1, β, Y, par...) ./ Γ(β .+ 2)
-                    σ = sqrt(sum((Y11 .- Y[2, :]) .^ 2))
-                    Y[2, :] .= Y11
-
-                end
-
-            else
+            if StopIt == "Standard"
 
                 for j in 1:nc
 
@@ -41,9 +28,21 @@ function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc::Any = 3, tol = 10e-10
                     σ = sqrt(sum((Y11 .- Y[2, :]) .^ 2))
                     Y[2, :] .= Y11
 
-                    if σ < tol
-                        warn('Correction below tolerance!')
-                    end
+                end
+
+            elseif StopIt == "Convergence"
+
+                σ = 1.1 * tol
+                j = 0
+
+                while (σ > tol && j < itmax)
+
+                    # Y11
+                    Y11 = T0 .+ h .^ β .* β .* F(t, n, β, Y, par...) ./ Γ(β .+ 2) .+ h .^ β .* F(t, n + 1, β, Y, par...) ./ Γ(β .+ 2)
+                    σ = sqrt(sum((Y11 .- Y[2, :]) .^ 2))
+                    Y[2, :] .= Y11
+
+                    j += 1
 
                 end
 
@@ -56,31 +55,30 @@ function FDEsolver(F, tSpan, y0, β, par...; h = 0.01, nc::Any = 3, tol = 10e-10
             # Yp
             Y[n + 1, :] .= T0 .+ h .^ β .* (ϕ .- α(0, β) .* F(t, n - 1, β, Y, par...) .+ 2 .* α(0, β) .* F(t, n, β, Y, par...))
 
-            if nc == "Convergence"
-
-                σ = 1.1 * tol
-
-                while (σ > tol || j < itmax)
-
-                    # Y2
-                    Y2 = T0 .+ h .^ β .* (ϕ .+ α(0, β) .* F(t, n + 1, β, Y, par...))
-                    σ = sqrt(sum((Y2 .- Y[2, :]) .^ 2))
-                    Y[n + 1, :] .= Y2
-
-                end
-
-            else
+            if StopIt == "Standard"
 
                 for j in 1:nc
 
                     # Y2
                     Y2 = T0 .+ h .^ β .* (ϕ .+ α(0, β) .* F(t, n + 1, β, Y, par...))
-                    σ = sqrt(sum((Y2 .- Y[2, :]) .^ 2))
+                    σ = sqrt(sum((Y2 .- Y[n + 1, :]) .^ 2))
                     Y[n + 1, :] .= Y2
 
-                    if σ < tol
-                        warn('Correction below tolerance!')
-                    end
+                end
+
+            elseif StopIt == "Convergence"
+
+                σ = 1.1 * tol
+                j = 0
+
+                while (σ > tol && j < itmax)
+
+                    # Y2
+                    Y2 = T0 .+ h .^ β .* (ϕ .+ α(0, β) .* F(t, n + 1, β, Y, par...))
+                    σ = sqrt(sum((Y2 .- Y[n + 1, :]) .^ 2))
+                    Y[n + 1, :] .= Y2
+
+                    j += 1
 
                 end
 


### PR DESCRIPTION
Hi! The new optional parameter `StopIt` can take on two values: either "Standard" (by default) or "Convergence". In the former case, the function will repeat correction as many times as specified in `nc`; in the latter case, correction will stop only when tolerance or the iteration max is reached.